### PR TITLE
Add specs for media attachment validations

### DIFF
--- a/spec/fabricators/media_attachment_fabricator.rb
+++ b/spec/fabricators/media_attachment_fabricator.rb
@@ -1,3 +1,3 @@
 Fabricator(:media_attachment) do
-
+  account
 end

--- a/spec/services/post_status_service_spec.rb
+++ b/spec/services/post_status_service_spec.rb
@@ -7,4 +7,45 @@ RSpec.describe PostStatusService do
   it 'creates a new response status'
   it 'processes mentions'
   it 'pings PuSH hubs'
+
+  it 'does not allow attaching more than 4 files' do
+    account = Fabricate(:account)
+
+    expect do
+      PostStatusService.new.call(
+      account,
+      "test status update",
+      nil,
+      media_ids: [
+        Fabricate(:media_attachment, account: account),
+        Fabricate(:media_attachment, account: account),
+        Fabricate(:media_attachment, account: account),
+        Fabricate(:media_attachment, account: account),
+        Fabricate(:media_attachment, account: account),
+      ].map(&:id),
+    )
+    end.to raise_error(
+      Mastodon::ValidationError,
+      'Cannot attach more than 4 files',
+    )
+  end
+
+  it 'does not allow attaching both videos and images' do
+    account = Fabricate(:account)
+
+    expect do
+      PostStatusService.new.call(
+      account,
+      "test status update",
+      nil,
+      media_ids: [
+        Fabricate(:media_attachment, type: :video, account: account),
+        Fabricate(:media_attachment, type: :image, account: account),
+      ].map(&:id),
+    )
+    end.to raise_error(
+      Mastodon::ValidationError,
+      'Cannot attach a video to a toot that already contains images',
+    )
+  end
 end


### PR DESCRIPTION
There are currently not specs for the two media validations that are performed 
by `PostStatusService`. This adds specs for the validations that ensure that
you cannot attach more than four files, and that a status cannot have both
image and video attachments.